### PR TITLE
refact: 오래된 캐시 저장 문제 해결

### DIFF
--- a/app/src/main/java/com/yourcompany/digitaltok/ui/upload/ImageViewModel.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/ui/upload/ImageViewModel.kt
@@ -39,8 +39,11 @@ class ImageViewModel : ViewModel() {
             val binaryInfoResult = imageRepository.getImageBinaryInfo(imageId)
 
             binaryInfoResult.onSuccess { binaryInfo ->
-                // 2. 바이너리 데이터 다운로드
-                val downloadResult = imageRepository.downloadImageBinary(binaryInfo.einkDataUrl)
+                // 2. 바이너리 데이터 다운로드 (캐시 문제 해결)
+                // URL에 현재 시간을 쿼리 파라미터로 추가하여 매번 새로운 URL인 것처럼 요청합니다.
+                // 이렇게 하면 OkHttp 캐시가 이전 응답을 재사용하는 것을 방지할 수 있습니다.
+                val urlWithCacheBust = "${binaryInfo.einkDataUrl}?t=${System.currentTimeMillis()}"
+                val downloadResult = imageRepository.downloadImageBinary(urlWithCacheBust)
 
                 downloadResult.onSuccess { responseBody ->
                     val bytes = responseBody.bytes()


### PR DESCRIPTION
서버에서 변경된 URL을 받아올 때 이전 사용했던 데이터 대신 새롭게 받은 데이터 사용하도록 수정

Closes #41