### PR TITLE
[Feat] 템플릿 API 연동

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-01-15T07:06:16.412811800Z">
+        <DropdownSelection timestamp="2026-02-11T09:36:34.365196Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\최선우\.android\avd\Pixel_6.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CN80ZQAHE" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,5 +91,7 @@ dependencies {
     // Image Cropper
     implementation("com.github.CanHub:Android-Image-Cropper:4.5.0")
     implementation("com.github.chrisbanes:PhotoView:2.3.0")
+    
+    implementation("com.github.bumptech.glide:okhttp3-integration:4.12.0")
 
 }

--- a/app/src/main/java/com/yourcompany/digitaltok/data/model/Image.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/data/model/Image.kt
@@ -112,25 +112,3 @@ data class ImageMeta(
     @SerializedName("hasHeader")
     val hasHeader: Boolean
 )
-
-/**
- * GET /templates/priority API 응답의 `items` 배열에 포함된 개별 템플릿 정보
- */
-data class PriorityTemplate(
-    @SerializedName("templateId")
-    val templateId: Int,
-    @SerializedName("priorityType")
-    val priorityType: String,
-    @SerializedName("templateImageUrl")
-    val templateImageUrl: String
-)
-
-/**
- * GET /templates/priority API의 `result` 필드에 해당하는 데이터 클래스
- */
-data class PriorityTemplateResponse(
-    @SerializedName("count")
-    val count: Int,
-    @SerializedName("items")
-    val items: List<PriorityTemplate>
-)

--- a/app/src/main/java/com/yourcompany/digitaltok/data/model/Priority.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/data/model/Priority.kt
@@ -1,0 +1,37 @@
+package com.yourcompany.digitaltok.data.model
+
+import com.google.gson.annotations.SerializedName
+
+
+// GET /templates/priority API 응답의 `items` 배열에 포함된 개별 템플릿 정보
+
+data class PriorityTemplate(
+    @SerializedName("templateId")
+    val templateId: Int,
+    @SerializedName("priorityType")
+    val priorityType: String,
+    @SerializedName("templateImageUrl")
+    val templateImageUrl: String?
+)
+
+
+// GET /templates/priority API의 `result` 필드에 해당하는 데이터 클래스
+
+data class PriorityTemplateResponse(
+    @SerializedName("count")
+    val count: Int,
+    @SerializedName("items")
+    val items: List<PriorityTemplate>
+)
+
+
+data class PriorityTemplateDetail(
+    @SerializedName("templateId")
+    val templateId: Int,
+    @SerializedName("priority_type") // 목록 API와 달리, 상세 API는 priority_type 이라는 키를 사용
+    val priorityType: String,
+    @SerializedName("templateImageUrl")
+    val templateImageUrl: String,
+    @SerializedName("templateDataUrl")
+    val templateDataUrl: String
+)

--- a/app/src/main/java/com/yourcompany/digitaltok/data/network/ApiService.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/data/network/ApiService.kt
@@ -95,4 +95,9 @@ interface ApiService {
     // ==========================
     @GET("/api/v1/templates/priority")
     suspend fun getPriorityTemplates(): Response<ApiResponse<PriorityTemplateResponse>>
+
+    @GET("/api/v1/templates/priority/{templateId}")
+    suspend fun getPriorityTemplateDetail(
+        @Path("templateId") templateId: Int
+    ): Response<ApiResponse<PriorityTemplateDetail>>
 }

--- a/app/src/main/java/com/yourcompany/digitaltok/data/network/OkHttpGlideModule.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/data/network/OkHttpGlideModule.kt
@@ -1,0 +1,24 @@
+package com.yourcompany.digitaltok.data.network
+
+import android.content.Context
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Registry
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
+import com.bumptech.glide.load.model.GlideUrl
+import com.bumptech.glide.module.AppGlideModule
+import java.io.InputStream
+
+@GlideModule
+class OkHttpGlideModule : AppGlideModule() {
+
+    override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
+        // RetrofitClient에서 사용하는 인증된 OkHttpClient를 그대로 사용합니다.
+        val client = RetrofitClient.authenticatedOkHttpClient
+        registry.replace(
+            GlideUrl::class.java,
+            InputStream::class.java,
+            OkHttpUrlLoader.Factory(client)
+        )
+    }
+}

--- a/app/src/main/java/com/yourcompany/digitaltok/data/network/RetrofitClient.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/data/network/RetrofitClient.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit
 
 object RetrofitClient {
 
-    private const val BASE_URL = "http://3.37.213.174:8080/api/v1/"
+    private const val BASE_URL = "https://www.diring.site/api/v1/"
     private const val PREFS_NAME = "auth_prefs"
     private const val KEY_ACCESS_TOKEN = "accessToken"
 
@@ -32,7 +32,7 @@ object RetrofitClient {
         return prefs.getString(KEY_ACCESS_TOKEN, null)
     }
 
-    private val authenticatedOkHttpClient: OkHttpClient by lazy {
+    val authenticatedOkHttpClient: OkHttpClient by lazy {
         val authInterceptor = Interceptor { chain ->
             val originalRequest = chain.request()
             val accessToken = getAccessTokenFromPrefs()

--- a/app/src/main/java/com/yourcompany/digitaltok/data/repository/PriorityRepository.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/data/repository/PriorityRepository.kt
@@ -1,0 +1,46 @@
+package com.yourcompany.digitaltok.data.repository
+
+import com.yourcompany.digitaltok.data.model.PriorityTemplate
+import com.yourcompany.digitaltok.data.model.PriorityTemplateDetail
+import com.yourcompany.digitaltok.data.network.RetrofitClient
+
+class PriorityRepository {
+
+    private val apiService = RetrofitClient.apiService
+
+    suspend fun getPriorityTemplates(): Result<List<PriorityTemplate>> = try {
+        val response = apiService.getPriorityTemplates()
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null && body.isSuccess && body.result != null) {
+                Result.success(body.result.items)
+            } else {
+                val errorMessage = body?.message ?: "Unknown error"
+                Result.failure(Exception(errorMessage))
+            }
+        } else {
+            val errorBody = response.errorBody()?.string() ?: "Unknown HTTP error"
+            Result.failure(Exception("API Error ${response.code()}: $errorBody"))
+        }
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun getPriorityTemplateDetail(templateId: Int): Result<PriorityTemplateDetail> = try {
+        val response = apiService.getPriorityTemplateDetail(templateId)
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null && body.isSuccess && body.result != null) {
+                Result.success(body.result)
+            } else {
+                val errorMessage = body?.message ?: "Unknown error"
+                Result.failure(Exception(errorMessage))
+            }
+        } else {
+            val errorBody = response.errorBody()?.string() ?: "Unknown HTTP error"
+            Result.failure(Exception("API Error ${response.code()}: $errorBody"))
+        }
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+}

--- a/app/src/main/java/com/yourcompany/digitaltok/ui/decorate/DecorateAdapter.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/ui/decorate/DecorateAdapter.kt
@@ -50,22 +50,12 @@ class DecorateAdapter(
                 .load(item.previewUrl)
                 .placeholder(R.drawable.ic_launcher_background) // 로딩 중 이미지
                 .into(holder.ivThumb)
+        } else if (item.imageUri != null) {
+            holder.ivThumb.visibility = View.VISIBLE
+            holder.ivThumb.setImageURI(item.imageUri)
         } else {
-             // 로컬 Uri나 Res가 있는 경우 (예: 갤러리에서 방금 추가한 사진)
-            when {
-                item.imageUri != null -> {
-                    holder.ivThumb.visibility = View.VISIBLE
-                    holder.ivThumb.setImageURI(item.imageUri)
-                }
-                item.imageRes != null -> {
-                    holder.ivThumb.visibility = View.VISIBLE
-                    holder.ivThumb.setImageResource(item.imageRes)
-                }
-                else -> {
-                    holder.ivThumb.setImageDrawable(null)
-                    holder.ivThumb.visibility = View.GONE
-                }
-            }
+            holder.ivThumb.setImageDrawable(null)
+            holder.ivThumb.visibility = View.GONE
         }
 
         // --- 즐겨찾기(별) 상태 표시 ---

--- a/app/src/main/java/com/yourcompany/digitaltok/ui/decorate/DecorateFragment.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/ui/decorate/DecorateFragment.kt
@@ -12,13 +12,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.core.widget.addTextChangedListener
@@ -27,9 +25,7 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.button.MaterialButton
 import com.google.android.material.button.MaterialButtonToggleGroup
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.yourcompany.digitaltok.R
@@ -39,7 +35,6 @@ import java.io.File
 class DecorateFragment : Fragment() {
 
     private val viewModel: DecorateViewModel by viewModels()
-    private var loadingDialog: AlertDialog? = null
 
     // TOP BAR
     private lateinit var connectTopAppBar: View
@@ -58,35 +53,34 @@ class DecorateFragment : Fragment() {
 
     // ----- Template menu (2 items) -----
     private lateinit var rvTemplateList: RecyclerView
-    private lateinit var templateAdapter: TemplateAdapter
+    private lateinit var templateAdapter: PriorityAdapter
 
     // ----- Stations list (reused UI) -----
     private lateinit var tilSearch: TextInputLayout
     private lateinit var etSearch: TextInputEditText
     private lateinit var tvStationHint: TextView
     private lateinit var rvStations: RecyclerView
-    private lateinit var stationAdapter: TemplateAdapter
+    private lateinit var stationAdapter: PriorityAdapter
     private val shownStations = mutableListOf<TemplateItem>()
 
     // ----- Transport seats list -----
     private lateinit var rvTransportSeats: RecyclerView
-    private lateinit var transportAdapter: TemplateAdapter
+    private lateinit var transportAdapter: PriorityAdapter
     private lateinit var tvTabHint: TextView
 
     private val shownTransport = mutableListOf<TemplateItem>()
 
     private enum class Tab { RECENT, TEMPLATE }
     private var currentTab: Tab = Tab.RECENT
+
     private enum class TemplateScreen {
         MENU,                  // 템플릿 메뉴(2개)
         SEAT_LIST,             // 교통약자 좌석 리스트
-        STATION_LIST_FROM_MENU,// 지하철역 클릭으로 들어온 역 리스트(A)
-        STATION_LIST_FROM_SEAT // 임산부석 등 좌석 클릭으로 들어온 역 리스트(B)
+        STATION_LIST_FROM_MENU // 지하철역 클릭으로 들어온 역 리스트(A)
     }
     private var currentScreen: TemplateScreen = TemplateScreen.MENU
 
     // API 분기용 선택값
-    private var selectedSeatId: String? = null
     private var selectedStationId: String? = null
 
     private val maxSlots = 15
@@ -95,7 +89,7 @@ class DecorateFragment : Fragment() {
     private var recentItems = mutableListOf<DecorateItem>()
 
     // 템플릿 메뉴 2개
-    private val templateList = listOf(
+    private var templateList = mutableListOf(
         TemplateItem(
             id = "template_transport",
             title = "교통약자 좌석",
@@ -108,13 +102,6 @@ class DecorateFragment : Fragment() {
             desc = "지하철 노선별로 정리된 템플릿",
             thumbRes = R.drawable.blank_img
         )
-    )
-
-    // 교통약자 좌석 리스트(샘플)
-    private val allTransportSeats: List<TemplateItem> = listOf(
-        TemplateItem("ts_pregnant", "임산부석", "UX라이팅 필요", R.drawable.blank_img),
-        TemplateItem("ts_elder", "노약자석", "UX라이팅 필요", R.drawable.blank_img),
-        TemplateItem("ts_disabled", "장애인석", "UX라이팅 필요", R.drawable.blank_img),
     )
 
     // 역 리스트(샘플)
@@ -224,60 +211,37 @@ class DecorateFragment : Fragment() {
 
         // ----- template menu (2 items) -----
         rvTemplateList.layoutManager = LinearLayoutManager(requireContext())
-        templateAdapter = TemplateAdapter(templateList) { item ->
+        templateAdapter = PriorityAdapter(templateList) { item ->
             when (item.id) {
-                "template_station" -> {
-                    // 템플릿 메뉴 → 지하철역 → 역 리스트(A)
-                    selectedSeatId = null
-                    showStationListFromMenu()
-                }
-
-                "template_transport" -> {
-                    // 템플릿 메뉴 → 교통약자 → 좌석 리스트
-                    selectedSeatId = null
-                    showSeatList()
-                }
+                "template_station" -> showStationListFromMenu()
+                "template_transport" -> showSeatList()
             }
         }
         rvTemplateList.adapter = templateAdapter
 
         // ----- transport seats list -----
         rvTransportSeats.layoutManager = LinearLayoutManager(requireContext())
-        shownTransport.clear()
-        shownTransport.addAll(allTransportSeats)
-        transportAdapter = TemplateAdapter(shownTransport) { seat ->
-            // 교통약자 → 좌석 클릭(예: 임산부석) → 역 리스트(B)
-            selectedSeatId = seat.id
-            showStationListFromSeat(seatTitle = seat.title)
+        transportAdapter = PriorityAdapter(shownTransport) { seat ->
+            seat.id.toIntOrNull()?.let {
+                viewModel.fetchPriorityTemplateDetail(it)
+            }
         }
         rvTransportSeats.adapter = transportAdapter
 
-        // ----- stations list (UI reused for A/B) -----
+        // ----- stations list (UI reused for A) -----
         rvStations.layoutManager = LinearLayoutManager(requireContext())
-        shownStations.clear()
-        shownStations.addAll(allStations)
-        stationAdapter = TemplateAdapter(shownStations) { station ->
+        stationAdapter = PriorityAdapter(shownStations) { station ->
             selectedStationId = station.id
 
             when (currentScreen) {
                 TemplateScreen.STATION_LIST_FROM_MENU -> {
-                    // 나중에 “지하철역 경로” 상세 API
-                    Toast.makeText(requireContext(),
+                    Toast.makeText(
+                        requireContext(),
                         "역 상세(지하철역 경로): ${station.title}",
                         Toast.LENGTH_SHORT
                     ).show()
                     // TODO: apiStation.getStationDetail(station.id)
                 }
-
-                TemplateScreen.STATION_LIST_FROM_SEAT -> {
-                    // 나중에 “좌석 경로” 상세 API
-                    Toast.makeText(requireContext(),
-                        "역 상세(좌석 경로, seat=${selectedSeatId}): ${station.title}",
-                        Toast.LENGTH_SHORT
-                    ).show()
-                    // TODO: apiSeat.getStationDetailForSeat(selectedSeatId!!, station.id)
-                }
-
                 else -> Unit
             }
         }
@@ -285,14 +249,8 @@ class DecorateFragment : Fragment() {
 
         // ----- search: stations list에서만 -----
         etSearch.addTextChangedListener { editable ->
-            if (currentScreen != TemplateScreen.STATION_LIST_FROM_MENU &&
-                currentScreen != TemplateScreen.STATION_LIST_FROM_SEAT
-            ) return@addTextChangedListener
-
+            if (currentScreen != TemplateScreen.STATION_LIST_FROM_MENU) return@addTextChangedListener
             val q = editable?.toString()?.trim().orEmpty()
-
-            // 지금은 로컬 필터
-            // 나중에 source에 따라 API 검색으로도 분리 가능
             applyStationFilterLocal(q)
         }
 
@@ -326,14 +284,13 @@ class DecorateFragment : Fragment() {
             if (selected.id.startsWith("user_") && selected.imageUri != null) {
                 val imageFile = uriToFile(selected.imageUri)
                 if (imageFile != null) {
-                    viewModel.uploadImage(imageFile) // 업로드 후 observeViewModel에서 처리
+                    viewModel.uploadImage(imageFile)
                 } else {
                     Toast.makeText(requireContext(), "이미지 파일을 준비할 수 없습니다.", Toast.LENGTH_SHORT).show()
                 }
                 return@setOnClickListener
             }
 
-            // 3. 예외 케이스
             Toast.makeText(requireContext(), "이미지를 처리할 수 없습니다.", Toast.LENGTH_SHORT).show()
         }
 
@@ -342,8 +299,7 @@ class DecorateFragment : Fragment() {
     }
 
     private fun updateBackButtonVisibility() {
-        if (!::topBarBack.isInitialized) return  // 안전장치
-
+        if (!::topBarBack.isInitialized) return
         val show = (currentTab == Tab.TEMPLATE && currentScreen != TemplateScreen.MENU)
         topBarBack.visibility = if (show) View.VISIBLE else View.GONE
     }
@@ -352,13 +308,9 @@ class DecorateFragment : Fragment() {
     private fun setupOnBackPressed() {
         val callback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                // 템플릿 탭의 하위 메뉴(좌석 리스트, 역 리스트 등)에 있을 경우
                 if (currentTab == Tab.TEMPLATE && currentScreen != TemplateScreen.MENU) {
-                    // 이전 화면인 템플릿 메뉴로 돌아감
                     showTemplateMenu()
                 } else {
-                    // 그 외의 경우(최근 사진 탭, 템플릿 첫 화면)에는 기본 뒤로가기 동작 수행
-                    // 콜백을 비활성화하고, 액티비티의 기본 뒤로가기 로직을 다시 호출
                     isEnabled = false
                     requireActivity().onBackPressedDispatcher.onBackPressed()
                 }
@@ -368,7 +320,6 @@ class DecorateFragment : Fragment() {
     }
 
     // ----- TAB CONTROL -----
-
     private fun setTab(tab: Tab) {
         currentTab = tab
         val isRecent = tab == Tab.RECENT
@@ -387,7 +338,6 @@ class DecorateFragment : Fragment() {
             rvStations.visibility = View.GONE
 
             currentScreen = TemplateScreen.MENU
-            selectedSeatId = null
             selectedStationId = null
 
             val filled = recentItems.count { !it.isSlot }
@@ -403,7 +353,6 @@ class DecorateFragment : Fragment() {
         updateSendButtonUI()
     }
 
-
     private fun showTemplateMenu() {
         currentScreen = TemplateScreen.MENU
 
@@ -418,7 +367,6 @@ class DecorateFragment : Fragment() {
         updateBackButtonVisibility()
     }
 
-
     private fun showSeatList() {
         currentScreen = TemplateScreen.SEAT_LIST
 
@@ -430,13 +378,9 @@ class DecorateFragment : Fragment() {
         rvStations.visibility = View.GONE
 
         etSearch.setText("")
-        shownTransport.clear()
-        shownTransport.addAll(allTransportSeats)
-        transportAdapter.notifyDataSetChanged()
 
         updateBackButtonVisibility()
     }
-
 
     private fun showStationListFromMenu() {
         currentScreen = TemplateScreen.STATION_LIST_FROM_MENU
@@ -456,37 +400,8 @@ class DecorateFragment : Fragment() {
         updateBackButtonVisibility()
     }
 
-    private fun showStationListFromSeat(seatTitle: String) {
-        currentScreen = TemplateScreen.STATION_LIST_FROM_SEAT
-
-        rvTemplateList.visibility = View.GONE
-        rvTransportSeats.visibility = View.GONE
-        tilSearch.visibility = View.VISIBLE
-        tvStationHint.visibility = View.VISIBLE
-        rvStations.visibility = View.VISIBLE
-
-        tvStationHint.text = "${seatTitle}에 적용할 역을 선택해 주세요"
-        etSearch.hint = "더 많은 역을 검색해 보세요"
-        etSearch.setText("")
-
-        loadStationsForSeat(selectedSeatId)
-
-        updateBackButtonVisibility()
-    }
-
-
-
     // -------------------- DATA LOADING (NOW: SAMPLE / LATER: API) --------------------
-
     private fun loadStationsForMenu() {
-        // TODO: API A (지하철역 경로)로 교체
-        shownStations.clear()
-        shownStations.addAll(allStations)
-        stationAdapter.notifyDataSetChanged()
-    }
-
-    private fun loadStationsForSeat(seatId: String?) {
-        // TODO: API B (좌석 경로)로 교체 (seatId 사용)
         shownStations.clear()
         shownStations.addAll(allStations)
         stationAdapter.notifyDataSetChanged()
@@ -510,7 +425,6 @@ class DecorateFragment : Fragment() {
     }
 
     // -------------------- RECENT BUTTON UI --------------------
-
     private fun updateSendButtonUI() {
         if (currentTab != Tab.RECENT) return
         val selected = gridAdapter.getSelectedItem()
@@ -527,7 +441,6 @@ class DecorateFragment : Fragment() {
     }
 
     // -------------------- IMAGE PICKER & CROP --------------------
-
     private fun showAddImageDialog() {
         val dialogView = layoutInflater.inflate(R.layout.bottom_sheet_image_picker, null, false)
 
@@ -535,7 +448,6 @@ class DecorateFragment : Fragment() {
             .setView(dialogView)
             .create()
 
-        // 클릭 이벤트
         dialogView.findViewById<TextView>(R.id.tvCamera).setOnClickListener {
             dialog.dismiss()
             openCamera()
@@ -546,26 +458,18 @@ class DecorateFragment : Fragment() {
             openGallery()
         }
 
-        dialogView.findViewById<MaterialButton>(R.id.btnCancel).setOnClickListener {
-            dialog.dismiss()
-        }
+        dialogView.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnCancel)
+            .setOnClickListener { dialog.dismiss() }
 
         dialog.setCanceledOnTouchOutside(true)
         dialog.show()
 
-        // 윈도우 설정은 show() 이후에 해야 적용됨
         dialog.window?.let { w ->
-            // 1) 배경 투명 (dialogView의 카드/라운드가 보이게)
             w.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-
-            // 2) 딤 강제 ON
             w.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
             w.setDimAmount(0.55f)
-
-            // 3) 아래 붙이기
             w.setGravity(Gravity.BOTTOM)
 
-            // 4) 네비게이션 바 + margin 만큼 위로 올리기
             val navBarHeightPx = run {
                 val resId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
                 if (resId > 0) resources.getDimensionPixelSize(resId) else 0
@@ -581,16 +485,12 @@ class DecorateFragment : Fragment() {
                 y = navBarHeightPx + marginPx
             }
 
-            // 5) 폭/높이
             w.setLayout(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
             )
         }
     }
-
-
-
 
     private fun openGallery() {
         pickImageLauncher.launch(
@@ -647,92 +547,133 @@ class DecorateFragment : Fragment() {
     }
 
     // -------------------- VIEWMODEL & UPLOAD --------------------
-
     private fun observeViewModel() {
+        // 교통약자 템플릿 목록
+        viewModel.priorityTemplatesState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is DecorateViewModel.PriorityTemplatesUiState.Loading -> {
+                    // no-op
+                }
+                is DecorateViewModel.PriorityTemplatesUiState.Success -> {
+                    // 상세 목록 (원래 코드)
+                    val newItems = state.templates.map {
+                        TemplateItem(
+                            id = it.templateId.toString(),
+                            title = it.priorityType,
+                            thumbUrl = it.templateImageUrl
+                        )
+                    }
+                    shownTransport.clear()
+                    shownTransport.addAll(newItems)
+                    transportAdapter.notifyDataSetChanged()
+
+                    // 메인 메뉴 아이템 썸네일 업데이트
+                    state.templates.firstOrNull()?.let { firstTemplate ->
+                        val transportMenuIndex = templateList.indexOfFirst { it.id == "template_transport" }
+                        if (transportMenuIndex != -1) {
+                            val oldItem = templateList[transportMenuIndex]
+                            templateList[transportMenuIndex] = oldItem.copy(
+                                thumbUrl = firstTemplate.templateImageUrl,
+                                thumbRes = 0 // URL 사용할 것이므로 리소스 ID는 0으로
+                            )
+                            templateAdapter.notifyItemChanged(transportMenuIndex)
+                        }
+                    }
+                }
+                is DecorateViewModel.PriorityTemplatesUiState.Error -> {
+                    Toast.makeText(requireContext(), state.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+
+        // 교통약자 템플릿 상세
+        viewModel.priorityTemplateDetailState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is DecorateViewModel.PriorityTemplateDetailUiState.Loading -> {
+                    // 로딩 표시가 필요하다면 여기에 구현
+                }
+                is DecorateViewModel.PriorityTemplateDetailUiState.Success -> {
+                    val detail = state.templateDetail
+                    // TODO: 템플릿 전용 미리보기 및 전송 로직 구현 위치입니다.
+                    // 현재는 'ImagePreviewFragment'로 이동하는 대신 Toast 메시지만 표시합니다.
+                    // 'detail.templateImageUrl'과 'detail.templateDataUrl'을 사용하여
+                    // 새로운 미리보기 화면을 구성하고 바이너리 데이터를 기기에 전송하는 로직을 여기에 추가하세요.
+                    Toast.makeText(requireContext(), "템플릿 선택됨: ${detail.priorityType}", Toast.LENGTH_SHORT).show()
+                }
+                is DecorateViewModel.PriorityTemplateDetailUiState.Error -> {
+                    Toast.makeText(requireContext(), state.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+
         viewModel.uploadState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is DecorateViewModel.UploadUiState.Loading -> {
-                    showLoadingDialog()
+                    // no-op
                 }
                 is DecorateViewModel.UploadUiState.Success -> {
-                    hideLoadingDialog()
-                    // 업로드 성공 시, 미리보기 화면으로 이동
                     val result = state.result
                     goToPreviewScreen(result.image.imageId, result.image.previewUrl)
-
                 }
                 is DecorateViewModel.UploadUiState.Error -> {
-                    hideLoadingDialog()
                     Toast.makeText(requireContext(), "업로드 실패: ${state.message}", Toast.LENGTH_LONG).show()
                 }
-                is DecorateViewModel.UploadUiState.Idle -> {
-                    hideLoadingDialog()
-                }
+                is DecorateViewModel.UploadUiState.Idle -> Unit
             }
         }
 
         viewModel.favoriteState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is DecorateViewModel.FavoriteUiState.Loading -> {
-                    // 로딩 중 UI 표시가 필요하다면 여기에 구현 (예: 작은 스피너 표시)
+                    // no-op
                 }
                 is DecorateViewModel.FavoriteUiState.Success -> {
                     viewModel.fetchRecentImages()
                 }
                 is DecorateViewModel.FavoriteUiState.Error -> {
                     Toast.makeText(requireContext(), "오류: ${state.message}", Toast.LENGTH_SHORT).show()
-                    // 참고: API 에러 발생 시, 어댑터의 UI 상태를 원래대로 되돌리는 로직을 추가하면
-                    // 더 안정적인 사용자 경험을 제공할 수 있습니다.
                     viewModel.fetchRecentImages()
                 }
-                is DecorateViewModel.FavoriteUiState.Idle -> {
-                    // 아무것도 안 함
-                }
+                is DecorateViewModel.FavoriteUiState.Idle -> Unit
             }
         }
 
         viewModel.recentImagesState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is DecorateViewModel.RecentImagesUiState.Loading -> {
-                    // 로딩 UI 표시 없음 (사용자 요청)
+                    // no-op
                 }
                 is DecorateViewModel.RecentImagesUiState.Success -> {
                     val recentApiItems = state.response.items
 
-                    // 1. API 응답을 UI 모델 (DecorateItem) 리스트로 변환
                     val newItems = recentApiItems.map {
                         DecorateItem(
                             id = it.imageId.toString(),
-                            previewUrl = it.previewUrl, // 서버 URL을 올바르게 할당
-                            isFavorite = it.isFavorite, // 즐겨찾기 상태를 올바르게 할당
+                            previewUrl = it.previewUrl,
+                            isFavorite = it.isFavorite,
                             isSlot = false
                         )
                     }
 
-                    // 2. 즐겨찾기 된 아이템들을 위로 정렬
                     val sortedItems = newItems.sortedWith(compareByDescending { it.isFavorite })
 
-                    // 3. Fragment의 메인 리스트를 교체
                     recentItems.clear()
                     recentItems.addAll(sortedItems)
 
-                    // 4. 최대 슬롯(15개)에 맞춰 빈 아이템 추가
                     val emptySlots = maxSlots - recentItems.size
                     if (emptySlots > 0) {
-                        repeat(emptySlots) { idx -> recentItems.add(DecorateItem(id = "slot_$idx", isSlot = true)) }
+                        repeat(emptySlots) { idx ->
+                            recentItems.add(DecorateItem(id = "slot_$idx", isSlot = true))
+                        }
                     }
 
-                    // 5. 어댑터에 최종 리스트와 즐겨찾기 정보 전달
                     gridAdapter.submitList(recentItems.toList())
-
-                    // 6. 상단 카운트 UI 업데이트
                     updateCountUI()
                 }
                 is DecorateViewModel.RecentImagesUiState.Error -> {
                     Toast.makeText(requireContext(), "최근 이미지 로딩 실패: ${state.message}", Toast.LENGTH_SHORT).show()
-                    // TODO: 이미지 로딩 실패 시 UI/UX 개선 (예: 재시도 버튼 표시)
                 }
-                else -> { /* Idle */ }
+                else -> Unit
             }
         }
     }
@@ -751,7 +692,6 @@ class DecorateFragment : Fragment() {
     private fun uriToFile(uri: Uri): File? {
         return try {
             val inputStream = requireContext().contentResolver.openInputStream(uri) ?: return null
-            // Create a temporary file in the cache directory
             val file = File(requireContext().cacheDir, "upload_${System.currentTimeMillis()}.jpg")
             file.outputStream().use { fileOut ->
                 inputStream.copyTo(fileOut)
@@ -762,24 +702,5 @@ class DecorateFragment : Fragment() {
             e.printStackTrace()
             null
         }
-    }
-
-    private fun showLoadingDialog() {
-        if (loadingDialog == null) {
-            val progressBar = ProgressBar(requireContext()).apply {
-                val padding = 100
-                setPadding(padding, padding, padding, padding)
-            }
-            loadingDialog = MaterialAlertDialogBuilder(requireContext())
-                .setTitle("업로드 중...")
-                .setView(progressBar)
-                .setCancelable(false)
-                .create()
-        }
-        loadingDialog?.show()
-    }
-
-    private fun hideLoadingDialog() {
-        loadingDialog?.dismiss()
     }
 }

--- a/app/src/main/java/com/yourcompany/digitaltok/ui/decorate/DecorateItem.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/ui/decorate/DecorateItem.kt
@@ -2,15 +2,18 @@ package com.yourcompany.digitaltok.ui.decorate
 
 import android.net.Uri
 
-/**
- * '꾸미기' 탭의 그리드에 표시될 아이템을 나타내는 데이터 클래스입니다.
- * 이 클래스는 UI 표현에 필요한 모든 정보를 담고 있습니다.
- */
 data class DecorateItem(
-    val id: String, // 서버 이미지의 경우 imageId, 로컬 슬롯의 경우 고유 ID
-    val previewUrl: String? = null, // 서버에서 받은 썸네일 URL
-    val isFavorite: Boolean = false, // 즐겨찾기 상태
-    val imageUri: Uri? = null, // 갤러리/카메라에서 가져온 로컬 이미지 Uri
-    val imageRes: Int? = null, // (필요 시) 드로어블 리소스 ID
-    val isSlot: Boolean = true // 최근 사진 목록의 빈 슬롯 여부
-)
+    val id: String, // 서버 이미지 ID 또는 로컬 임시 ID
+    val title: String = "",
+    val previewUrl: String? = null, // Glide로 로드할 URL (서버)
+    val imageUri: Uri? = null, // Glide로 로드할 Uri (로컬)
+    var isSlot: Boolean = false,
+    var isFavorite: Boolean = false,
+    var isSelected: Boolean = false, // 선택 상태
+    val onAddClick: (() -> Unit)? = null // 추가 버튼 클릭 리스너
+) {
+    companion object {
+        fun createAddSlot(onClick: () -> Unit) = DecorateItem(id = "add_slot", isSlot = true, onAddClick = onClick)
+        fun createEmptySlot() = DecorateItem(id = "empty_slot", isSlot = true)
+    }
+}

--- a/app/src/main/java/com/yourcompany/digitaltok/ui/decorate/PriorityAdapter.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/ui/decorate/PriorityAdapter.kt
@@ -1,0 +1,64 @@
+package com.yourcompany.digitaltok.ui.decorate
+
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.yourcompany.digitaltok.R
+
+class PriorityAdapter(
+    private val items: List<TemplateItem>,
+    private val onItemClick: (TemplateItem) -> Unit
+) : RecyclerView.Adapter<PriorityAdapter.VH>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_station_template, parent, false)
+        return VH(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        val item = items[position]
+        holder.bind(item)
+    }
+
+    inner class VH(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val ivThumb: ImageView = itemView.findViewById(R.id.ivThumb)
+        private val tvTitle: TextView = itemView.findViewById(R.id.tvName) // R.id.tvTitle -> R.id.tvName
+        private val tvDesc: TextView = itemView.findViewById(R.id.tvDesc)
+
+        init {
+            itemView.setOnClickListener {
+                val position = adapterPosition
+                if (position != RecyclerView.NO_POSITION) {
+                    onItemClick(items[position])
+                }
+            }
+        }
+
+        fun bind(item: TemplateItem) {
+            tvTitle.text = item.title
+            tvDesc.text = item.desc
+
+            Log.d("PriorityAdapter", "Binding item: title='${item.title}', url='${item.thumbUrl}'")
+
+            if (!item.thumbUrl.isNullOrEmpty()) {
+                Glide.with(itemView.context)
+                    .load(item.thumbUrl)
+                    .placeholder(R.drawable.blank_img)
+                    .error(R.drawable.blank_img)
+                    .into(ivThumb)
+            } else if (item.thumbRes != 0) {
+                ivThumb.setImageResource(item.thumbRes)
+            } else {
+                ivThumb.setImageResource(R.drawable.blank_img)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/yourcompany/digitaltok/ui/decorate/StationTemplateItem.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/ui/decorate/StationTemplateItem.kt
@@ -3,6 +3,7 @@ package com.yourcompany.digitaltok.ui.decorate
 data class TemplateItem(
     val id: String,
     val title: String,
-    val desc: String,
-    val thumbRes: Int
+    val desc: String = "",
+    val thumbRes: Int = 0,
+    val thumbUrl: String? = null
 )

--- a/app/src/main/res/layout/item_station_template.xml
+++ b/app/src/main/res/layout/item_station_template.xml
@@ -12,7 +12,6 @@
         android:layout_marginStart="14dp"
         android:layout_marginTop="14dp"
         android:layout_marginBottom="14dp"
-        android:background="@drawable/blank_img"
         android:scaleType="centerCrop"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
교통약자 템플릿 API 초기 구현 완료

템플릿 클릭 시, 기존 이미지 미리보기 화면(ImagePreviewFragment)으로 이동하는 로직을 제거함
->  새로운 템플릿 전용 미리보기 및 전송 로직을 구현하기 위한 준비 단계

서버에 맞춰 네트워크 통신의 보안 강화를 위해 Retrofit의 BASE_URL을 https로 변경

Closes #49 