### PR TITLE
[Bug] 캐시 중복 문제 해결

### DIFF
--- a/app/src/main/java/com/yourcompany/digitaltok/data/network/RetrofitClient.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/data/network/RetrofitClient.kt
@@ -1,11 +1,13 @@
 package com.yourcompany.digitaltok.data.network
 
 import android.content.Context
+import okhttp3.Cache
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 object RetrofitClient {
@@ -21,9 +23,22 @@ object RetrofitClient {
     @Volatile
     private var appContext: Context? = null
 
+    // 추가: OkHttp 캐시 인스턴스
+    private var okHttpCache: Cache? = null
+
     // Application.onCreate()에서 1번 호출
     fun init(context: Context) {
         appContext = context.applicationContext
+        // 추가: 캐시 초기화
+        if (okHttpCache == null) {
+            val cacheSize = (10 * 1024 * 1024).toLong() // 10 MB
+            okHttpCache = Cache(File(context.cacheDir, "http-cache"), cacheSize)
+        }
+    }
+
+    // 로그아웃 시 호출하여 OkHttp 캐시를 모두 삭제
+    fun clearCache() {
+        okHttpCache?.evictAll()
     }
 
     fun providePublicOkHttpClient(): OkHttpClient = publicOkHttpClient
@@ -54,6 +69,7 @@ object RetrofitClient {
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .writeTimeout(60, TimeUnit.SECONDS)
+            .cache(okHttpCache) // 추가: 캐시 사용
             .build()
     }
 
@@ -64,6 +80,7 @@ object RetrofitClient {
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .writeTimeout(60, TimeUnit.SECONDS)
+            .cache(okHttpCache) // 추가: 캐시 사용
             .build()
     }
 

--- a/app/src/main/java/com/yourcompany/digitaltok/data/repository/AccountRepository.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/data/repository/AccountRepository.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.yourcompany.digitaltok.data.model.EmailChangeRequest
 import com.yourcompany.digitaltok.data.model.LogoutRequest
 import com.yourcompany.digitaltok.data.network.AccountApiService
+import com.yourcompany.digitaltok.data.network.RetrofitClient
 
 class AccountRepository(
     private val api: AccountApiService,
@@ -20,7 +21,9 @@ class AccountRepository(
         val res = api.logout(LogoutRequest(refresh))
         if (!res.isSuccess) throw RuntimeException(res.message)
 
+        // 로그아웃 성공 시, 토큰 및 네트워크 캐시 모두 삭제
         authLocalStore.clearAuth()
+        RetrofitClient.clearCache()
     }
 
     suspend fun withdraw(): Result<Unit> = runCatching {
@@ -35,8 +38,10 @@ class AccountRepository(
 
         if (!res.isSuccess) throw RuntimeException(res.message)
 
+        // 회원탈퇴 성공 시, 토큰 및 네트워크 캐시 모두 삭제
         authLocalStore.clearAuth()
-        Log.d("Withdraw", "LOCAL AUTH CLEARED")
+        RetrofitClient.clearCache()
+        Log.d("Withdraw", "LOCAL AUTH and CACHE CLEARED")
     }
 
 

--- a/app/src/main/java/com/yourcompany/digitaltok/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/data/repository/AuthRepository.kt
@@ -16,12 +16,6 @@ class AuthRepository {
     suspend fun duplicateCheck(email: String) =
         api.duplicateCheck(DuplicateCheckRequest(email))
 
-    suspend fun passwordReset(email: String) =
-        api.passwordReset(PasswordResetRequest(email))
-
-    suspend fun logout(refreshToken: String) =
-        api.logout(LogoutRequest(refreshToken))
-
     suspend fun resetPassword(email: String) =
         api.passwordReset(PasswordResetRequest(email))
 

--- a/app/src/main/java/com/yourcompany/digitaltok/ui/auth/PasswordResetActivity.kt
+++ b/app/src/main/java/com/yourcompany/digitaltok/ui/auth/PasswordResetActivity.kt
@@ -77,7 +77,7 @@ class PasswordResetActivity : AppCompatActivity() {
         lifecycleScope.launch {
             try {
                 val res = withContext(Dispatchers.IO) {
-                    // ✅ AuthRepository 함수명에 맞춰 호출
+                    //  AuthRepository 함수명에 맞춰 호출
                     authRepository.resetPassword(email)
                     // 만약 네 레포지토리 함수명이 passwordReset(email) 이면 아래로 바꿔:
                     // authRepository.passwordReset(email)


### PR DESCRIPTION
- 캐시 제어 기능 추가: RetrofitClient에 Cache 인스턴스를 설정하고, 캐시를 프로그래매틱하게 비울 수 있는 clearCache() 함수를 추가했습니다.
- 로그아웃 로직 수정: AccountRepository의 logout() 함수가 서버로부터 성공 응답을 받으면, 기존의 토큰 삭제 로직에 더해 RetrofitClient.clearCache()를 호출하도록 수정했습니다
- 회원탈퇴 로직 수정: AccountRepository의 withdraw() 함수에도 동일하게 캐시 삭제 로직을 추가하여 일관성을 확보했습니다
-  불필요 코드 정리: 실제 로그아웃 로직과 무관한 AuthRepository의 중복 logout 함수를 제거하여 코드의 명확성을 높였습니다.

Closes #62 